### PR TITLE
Add tech post: mlrBinder (Miller from Java)

### DIFF
--- a/content/posts/tech/mlrBinder-Miller를 Java에서.md
+++ b/content/posts/tech/mlrBinder-Miller를 Java에서.md
@@ -1,31 +1,29 @@
 ---
-title: "mlrBinder: Miller(mlr)를 자바에서 fluent API로"
+title: "mlrBinder: Miller(mlr)를 자바에서 fluent API로 (README 한글판)"
 date: 2026-04-13T12:00:00+09:00
 draft: false
 ---
 
-CSV·JSON·TSV·DKVP 같은 구분 텍스트를 다룰 때 [Miller](https://miller.readthedocs.io/)(`mlr`)만큼 손에 익은 도구가 없다면, JVM 쪽 배치·서비스·테스트에서도 같은 워크플로를 쓰고 싶을 때가 있다. 이때 긴 셸 문자열을 이어 붙이거나 `Runtime.exec`에 argv 배열을 손으로 조립하는 대신, **타입과 메서드 이름으로 Miller 호출을 조립**할 수 있게 만든 라이브러리가 [mlrBinder](https://github.com/bluedskim/mlrBinder)다.
+이 글은 [mlrBinder](https://github.com/bluedskim/mlrBinder) 저장소 README를 **한국어로 옮긴 것**과 같이 읽으면 된다. 코드 블록 안의 식별자·명령행은 원문과 동일하게 두었다.
 
-## 무엇을 해 주는가
+[Miller](https://miller.readthedocs.io/)(`mlr`)는 CSV, JSON, TSV, DKVP 같은 구분 텍스트를 다루는 강력한 CLI 도구다. **mlr-binder**(저장소 이름: mlrBinder)는 Miller를 **유창한(fluent) 자바 API**로 바꿔 준다. 배치·서비스·테스트에서 손으로 셸 문자열을 짜거나 argv 목록을 복사·붙여넣기 하지 않고도 같은 일을 할 수 있다. **Miller Java Binder**는 실제 `mlr` **프로세스**를 감싸므로, 업스트림 Miller의 의미를 유지하면서 JVM 코드는 읽기 쉽고 리팩터링하기 좋게 남는다.
 
-- **실제 `mlr` 프로세스를 실행**한다. JNI로 Miller를 JVM에 묶는 것이 아니라, 조립한 인자 목록으로 `ProcessBuilder`가 `mlr`을 띄운다. 그래서 **업스트림 Miller의 동작**을 그대로 따르면서, 자바 코드만 읽기·리팩터링하기 좋은 형태로 쓸 수 있다.
-- **`Mlr` 체인**, `Flag`, `Verb`, `Option` 등으로 호출을 구성해 **문자열 수프**를 줄이고, IDE에서 이름·시그니처로 검토하기 쉽게 만든다.
-- Miller DSL(`put`, `filter` 등)은 여전히 문자열로 넘기며, **그 부분은 실행 시점에 `mlr`이 검증**한다는 점은 그대로다.
+---
 
-## 언제 쓰면 좋은가
+## 왜 쓰는가
 
-- ETL·데이터 준비 파이프라인에서 대용량 구분 파일을 정렬·절단·조인·집계할 때
-- 스케줄러·워커 같은 **백엔드·배치**에서 반복 가능한 `mlr` 워크플로를 자바로 고정할 때
-- 테스트에서 [Miller in 10 minutes](https://miller.readthedocs.io/en/latest/10min/) 스타일 흐름을 자바로 옮겨 **품질 게이트**로 두고 싶을 때
-- 분석 쪽은 Miller에 익숙하고, 애플리케이션 팀은 JVM만 쓰는 **폴리글랏** 환경에서 공통 의존성 하나로 맞출 때
+- **문자열 수프를 줄인다:** 명령을 이어 붙여 IDE에서 이름을 바꾸거나 리뷰하기 어렵게 만들지 말고, `Mlr` 체인과 `Flag`, `Verb`, `Option`으로 조립한다.
+- **실수를 더 일찍 잡는다:** 메서드 이름과 타입이 Miller 구조를 담는다. `put`·`filter` 같은 **Miller DSL 조각**만은 `mlr`이 돌 때까지 검증된다.
+- **빠르게 붙인다:** Maven 또는 Gradle 의존성 하나, `PATH`에 있는 `mlr`(또는 설정한 경로), 그다음 `Mlr.inDir(...).csv().sort(...).file(...).run()`이면 된다. JNI 네이티브 층이나 별도 서비스가 없다.
+- **Maven Central:** 좌표는 **`io.github.bluedskim:mlr-binder`**이며, 예시 버전 디렉터리는 [Central의 0.2 경로](https://repo1.maven.org/maven2/io/github/bluedskim/mlr-binder/0.2/)와 맞는다.
+
+---
 
 ## 설치
 
-**Java 11 이상**, 시스템에 **`mlr`이 PATH에 있거나** 설정한 경로에서 실행 가능해야 한다. 개발·테스트 기준 Miller 버전은 README 기준 **[mlr 6.17.0](https://github.com/johnkerl/miller/releases/tag/v6.17.0)**이다.
+**Java 11 이상**이 필요하다. 자바 패키지(타입이 들어 있는 패키지)는 **`net.shed.mlrbinder`**다.
 
-[Maven Central](https://repo1.maven.org/maven2/io/github/bluedskim/mlr-binder/0.2/)에 **`io.github.bluedskim:mlr-binder:0.2`**로 올라와 있다. 패키지 네임스페이스는 **`net.shed.mlrbinder`**다.
-
-Maven:
+Maven (`pom.xml`):
 
 ```xml
 <dependency>
@@ -43,31 +41,460 @@ dependencies {
 }
 ```
 
-## 한 줄 맛보기
+Gradle (Groovy):
 
-README에서 권장하는 스타일은 **전역 플래그는 `Mlr` 체인**, 동사(verb)는 **Miller와 같은 이름의 인스턴스 메서드**(`filter`·`split`만 `.filterVerb()` / `.splitVerb()`)다. 예를 들어 CSV를 읽어 `cat`만 돌리는 흐름은 대략 다음과 같이 쓸 수 있다.
-
-```java
-import net.shed.mlrbinder.Mlr;
-
-String out = Mlr.inDir("/path/to/data")
-    .csv()
-    .cat()
-    .file("example.csv")
-    .run();
+```groovy
+dependencies {
+    implementation 'io.github.bluedskim:mlr-binder:0.2'
+}
 ```
 
-쉘에서의 `mlr --csv cat example.csv`에 대응한다. `sort`, `cut`, `head`, `put`, `--from`, 파이프에 가까운 두 단계 처리 등은 저장소 README와 테스트(`TenMinTutorialE2eTest` 등)에 **Miller in 10 minutes 튜토리얼과 1:1에 가깝게** 매핑된 예제가 많다.
+---
 
-## 알아두면 좋은 제한
+## 활용 사례
 
-- **네이티브 바인딩이 아니다** — 반드시 외부 `mlr` 바이너리가 필요하다.
-- 잘못된 조합은 **`run()` 시점**에 종료 코드·stderr로 드러난다.
-- 일부 자바 메서드는 Miller CLI 그 자체가 아니라 **자주 쓰는 옵션 묶음(sugar)**이며, Javadoc에 대응하는 Miller CLI가 적혀 있다.
+- **데이터 준비·ETL:** JVM 파이프라인 안에서 대용량 구분 파일이나 JSON을 정렬·절단·조인·변형·집계하고, 엔진은 Miller로 둔다.
+- **백엔드·배치 작업:** 스케줄러나 워커에서 반복 가능한 `mlr` 흐름을 돌릴 때, 작업 디렉터리·파일 헬퍼를 쓰고 깨지기 쉬운 `Runtime.exec` 문자열 대신 API를 쓴다.
+- **품질 게이트·픽스처:** 아래의 “Miller in 10 minutes → 자바”처럼 [Miller in 10 minutes](https://miller.readthedocs.io/en/latest/10min/) 스타일 흐름을 테스트에 옮겨, 알려진 Miller 릴리스에 동작을 고정한다.
+- **폴리글랏 팀:** 분석가는 Miller에 익숙하게 두고, 애플리케이션 팀은 같은 동사(verb)를 자바에서 **공유 의존성 하나**로 호출한다.
 
-## 더 보기
+---
 
-- 소스·이슈·기여: [https://github.com/bluedskim/mlrBinder](https://github.com/bluedskim/mlrBinder)
+## 지원하는 Miller(`mlr`) 버전
+
+이 라이브러리는 Miller **[`mlr` 6.17.0](https://github.com/johnkerl/miller/releases/tag/v6.17.0)**에 맞춰 개발·테스트된다. `PATH`에 그 버전을 설치하거나, 다른 릴리스를 쓸 때는 동작을 직접 확인하는 것이 좋다.
+
+**바인더 전용 “설탕(sugar)”:** 일부 `Mlr` 메서드는 흔한 Miller 동사 옵션을 한 번에 묶는다(예: `uniqCountBy` → `uniq -c -g …`). 이런 **자바 이름은 Miller CLI 기능이 아니다.** 자식 프로세스는 항상 표준 `mlr`이다. 각 설탕 메서드는 Javadoc에 **대응하는 Miller CLI**를 적어 두었고, `net.shed.mlrbinder` 패키지 요약에는 한 표로 모아 두었다(생성된 Javadoc이나 IDE에서 `Mlr`/패키지 빠른 문서 참고).
+
+**권장 스타일:** 가능하면 **`Mlr` 체인 하나**로 끝낸다. 전역 플래그는 **`Mlr`의 전역 플래그 체인 메서드**(`.icsv()`, `.from("…")` 등)로, 동사는 **Miller 동사와 같은 이름의 인스턴스 메서드**(`.sort(…)`, `.cat()` 등; **`filter`/`split`만** `.filterVerb()` / `.splitVerb()`). `flag(Flags…)` + `verb(Mlr.Verbs…)` 조합은 **꼭 필요할 때만** 쓴다.
+
+---
+
+## 목표
+
+- **Miller를 부르는 방식:** 긴 명령 문자열을 이어 붙이지 않고, 가능한 한 **자바 메서드와 객체**로 Miller 동작을 표현한다. `Flag`, `Verb`, `Option`과 관련 타입으로 조립한다.
+- **컴파일 타임 검사:** API로 만든 부분(플래그 이름, 동사 이름, 인자 순서 등)은 타입·메서드 시그니처 수준에서 잡을 수 있다. Miller DSL(예: `put` 식)과 필드 이름 유효성은 여전히 **실행 시 `mlr`이 검사**하므로, 컴파일러가 전부를 막을 수는 없다.
+- **Miller 문법을 깊게 몰라도 쓰기:** 위 **권장 스타일**을 따르면 전역 플래그는 **`Mlr` 체인**에, 동사는 **Miller 동사와 같은 이름의 `Mlr` 메서드**에 둔다(예외: `filter` → `.filterVerb()`, `split` → `.splitVerb()`). 내부용·고급 조립에는 **`Mlr.Verbs`** 정적 팩터리도 있다. 세밀한 옵션은 Miller와 같은 인자를 `Flag`, `Objective`, `Option`으로 넘긴다. (`Verb`는 argv 조각일 뿐이니, 가능하면 애플리케이션 코드에서 `new Verb(...)`는 피한다.)
+- **실행:** 내부적으로 `ProcessBuilder`가 조립된 인자 목록으로 `mlr` 프로세스를 띄운다. `mlr`은 `PATH`에 설치되어 실행 가능해야 하며(또는 설정한 경로), **JVM 안에 Miller를 링크하지 않는다.**
+
+---
+
+## 범위와 한계
+
+- **거의 모든 동사:** Miller 동사마다 팩터리는 `net.shed.mlrbinder.verb.Verbs`에 있고, **`Mlr`의 동사 이름 인스턴스 메서드**와 **`Mlr.Verbs`** 모두 그쪽으로 위임한다. **전역 플래그**는 업스트림 [reference-main-flag-list](https://github.com/johnkerl/miller/blob/main/docs/src/reference-main-flag-list.md)를 따르며 `Flags`의 정적 팩터리로 제공되고, **`Mlr`에 맞는 체인 메서드**도 노출된다(`python3 utils/gen_flags.py`로 재생성). 문서에 없는 플래그는 `Flags.raw("--name")` / `Flags.raw("--name", "value")` 또는 동사 옵션으로 `Flag.flag("...")`를 쓴다. 가변 인자 뒤에 `--`가 오는 `--mfrom` / `--mload` 형태는 `Mlr#mfrom` / `#mload`를 쓴다.
+- **네이티브 바인딩이 아니다:** **외부 `mlr`을 실행**할 뿐, JVM 안에 Miller를 넣지 않는다.
+- **오류가 드러나는 시점:** 잘못된 조합은 `run()` / `run(InputStreamReader)`에서 종료 코드와 stderr로 나타난다.
+
+---
+
+## 테스트(저장소에서)
+
+```bash
+./gradlew :lib:test
+```
+
+- 리포트: `lib/build/reports/tests/test/index.html`, 커버리지: `lib/build/jacocoHtml/index.html` ([Jacoco](https://docs.gradle.org/current/userguide/jacoco_plugin.html))
+
+---
+
+## Miller in 10 minutes → 자바
+
+[Miller in 10 minutes](https://miller.readthedocs.io/en/latest/10min/)에 나오는 `mlr` 호출이 이 라이브러리에서 어떻게 대응하는지 정리한다. **아래 자바 예는 모두 권장 스타일**을 쓴다: **`Mlr.inDir(…)`**로 시작하고 필요하면 **`.csv()`**(`--csv`), 또는 정적 **`Mlr.withCsvPreset()`**(`mlr` + `--csv`를 먼저 두고 `workDir`/파일을 이어 붙임). 전역 플래그는 **`Mlr`에 체인**하고, 동사는 **이름이 같은 인스턴스 메서드**(`filter`/`split` → `.filterVerb` / `.splitVerb`). 같은 체인에 `--csv`를 또 붙이려면 **`.csv()`**를 다시 호출한다. **동사 옵션**은 `SortFlags`의 `f` / `n` / `nr`, `import static …Flag.flag`와 `flag("-f").objective("…")`, `option` / `objective` 등을 쓴다. 동사를 여러 개 이으면 `run()` argv에 **`then`이 자동 삽입**된다.
+
+실제 코드에서는 필요한 것만 고르면 된다. 아래는 공통으로 자주 쓰는 import 예시다.
+
+```java
+import static net.shed.mlrbinder.Flag.flag;
+import static net.shed.mlrbinder.Objective.objective;
+import static net.shed.mlrbinder.SortFlags.f;
+import static net.shed.mlrbinder.SortFlags.n;
+import static net.shed.mlrbinder.SortFlags.nr;
+import static net.shed.mlrbinder.verb.Option.option;
+
+import net.shed.mlrbinder.Mlr;
+```
+
+더 많은 패턴은 `TenMinTutorialE2eTest`, `TenMinTutorialFormatsE2eTest`(튜토리얼의 CSV/JSON/DKVP/TSV 형식 절), `lib/src/test/resources/10min/`을 보라.
+
+### 입출력 플래그와 `cat`
+
+```bash
+mlr --csv cat example.csv
+```
+
+```java
+Mlr.inDir(workingPath)
+	.csv()
+	.cat()
+	.file("example.csv")
+	.run();
+```
+
+```bash
+mlr --icsv --opprint cat example.csv
+```
+
+```java
+Mlr.inDir(workingPath)
+	.icsv()
+	.opprint()
+	.cat()
+	.file("example.csv")
+	.run();
+```
+
+### 파일 형식(CSV, JSON, DKVP, TSV)
+
+튜토리얼 “File formats” 절과 같이, `--csv` / `--json` / `--idkvp` / `--tsv` 등으로 입력 형식을 맞춘다.
+
+```bash
+mlr --csv cat shape.csv
+mlr --json cat shape.json
+mlr --idkvp --ocsv cat shape.dkvp
+mlr --tsv cat shape.tsv
+```
+
+```java
+Mlr.inDir(workingPath).csv().cat().file("shape.csv").run();
+Mlr.inDir(workingPath).jsonFlag().cat().file("shape.json").run();
+Mlr.inDir(workingPath).idkvp().ocsv().cat().file("shape.dkvp").run();
+Mlr.inDir(workingPath).tsv().cat().file("shape.tsv").run();
+```
+
+### `head` / `tail` 옵션
+
+```bash
+mlr --csv head -n 4 example.csv
+```
+
+```java
+Mlr.inDir(workingPath)
+	.csv()
+	.head(4)
+	.file("example.csv")
+	.run();
+```
+
+```bash
+mlr --csv tail -n 4 example.csv
+```
+
+```java
+Mlr.inDir(workingPath)
+	.csv()
+	.tail(4)
+	.file("example.csv")
+	.run();
+```
+
+### `sort`, `cut`
+
+```bash
+mlr --icsv --opprint sort -f shape -nr index example.csv
+```
+
+```java
+Mlr.inDir(workingPath)
+	.icsv()
+	.opprint()
+	.sort(f("shape"), nr("index"))
+	.file("example.csv")
+	.run();
+```
+
+```bash
+mlr --icsv --opprint cut -o -f flag,shape example.csv
+```
+
+```java
+Mlr.inDir(workingPath)
+	.icsv()
+	.opprint()
+	.cut(
+		option(flag("-o")),
+		option(flag("-f").objective("flag,shape")))
+	.file("example.csv")
+	.run();
+```
+
+### `filter` / `put`(DSL은 그대로 문자열)
+
+```bash
+mlr --icsv --opprint filter '$color == "red"' example.csv
+```
+
+```java
+Mlr.inDir(workingPath)
+	.icsv()
+	.opprint()
+	.filterVerb(objective("$color == \"red\""))
+	.file("example.csv")
+	.run();
+```
+
+```bash
+mlr --icsv --opprint put '$[[3]] = "NEW"' example.csv
+```
+
+```java
+Mlr.inDir(workingPath)
+	.icsv()
+	.opprint()
+	.put(objective("$[[3]] = \"NEW\""))
+	.file("example.csv")
+	.run();
+```
+
+### 공백이 있는 필드 이름(`-nr` 값은 셸 따옴표 없이도 하나의 토큰)
+
+```bash
+mlr --csv cat spaces.csv
+```
+
+```java
+Mlr.withCsvPreset()
+	.workDir(workingPath)
+	.cat()
+	.file("spaces.csv")
+	.run();
+```
+
+```bash
+mlr --c2p sort -nr 'Total MWh' spaces.csv
+```
+
+```java
+Mlr.inDir(workingPath)
+	.c2p()
+	.sort(nr("Total MWh"))
+	.file("spaces.csv")
+	.run();
+```
+
+```bash
+mlr --c2p put '${Total KWh} = ${Total MWh} * 1000' spaces.csv
+```
+
+```java
+Mlr.inDir(workingPath)
+	.c2p()
+	.put(objective("${Total KWh} = ${Total MWh} * 1000"))
+	.file("spaces.csv")
+	.run();
+```
+
+### 여러 입력 파일
+
+```bash
+mlr --csv cat data/a.csv data/b.csv
+```
+
+```java
+Mlr.inDir(workingPath)
+	.csv()
+	.cat()
+	.file("data/a.csv")
+	.file("data/b.csv")
+	.run();
+```
+
+### `then`으로 동사 연결
+
+```bash
+mlr --icsv --opprint sort -nr index then head -n 3 example.csv
+```
+
+```java
+Mlr.inDir(workingPath)
+	.icsv()
+	.opprint()
+	.sort(nr("index"))
+	.head(3)
+	.file("example.csv")
+	.run();
+```
+
+튜토리얼의 **셸 파이프**(`mlr … | mlr …`)는 자바에서는 **`Mlr` 호출 두 번**에 대응한다. 첫 단계 표준 출력을 임시 파일로 받으려면 `redirectOutputFile`을 쓰고, 두 번째 단계는 그 디렉터리에서 파일만으로 돌린다(표준 입력 없음).
+
+```bash
+mlr --csv sort -nr index example.csv | mlr --icsv --opprint head -n 3
+```
+
+```java
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+Path tmp = Files.createTempDirectory("mlr-pipe");
+Path sorted = tmp.resolve("sorted.csv");
+Mlr.inDir(workingPath)
+	.csv()
+	.sort(nr("index"))
+	.file("example.csv")
+	.redirectOutputFile(sorted.toFile())
+	.run();
+
+String pprintTop = Mlr.inDir(tmp.toString())
+	.icsv()
+	.opprint()
+	.head(3)
+	.file(sorted.getFileName().toString())
+	.run();
+```
+
+### `--from`
+
+```bash
+mlr --icsv --opprint --from example.csv sort -nr index then head -n 3
+```
+
+```java
+Mlr.inDir(workingPath)
+	.icsv()
+	.opprint()
+	.from("example.csv")
+	.sort(nr("index"))
+	.head(3)
+	.run();
+```
+
+### `--mfrom` / `--mload`(가변 인자 뒤의 `--`)
+
+```bash
+mlr --csv --mfrom a.csv b.csv -- cat
+```
+
+```java
+Mlr.inDir(workingPath)
+	.csv()
+	.mfrom("a.csv", "b.csv")
+	.cat()
+	.run();
+```
+
+### `stats1`처럼 옵션이 많은 동사
+
+```bash
+mlr --icsv --opprint --from example.csv stats1 -a count,min,mean,max -f quantity -g shape
+```
+
+```java
+Mlr.inDir(workingPath)
+	.icsv()
+	.opprint()
+	.from("example.csv")
+	.stats1(
+		flag("-a").objective("count,min,mean,max"),
+		flag("-f").objective("quantity"),
+		flag("-g").objective("shape"))
+	.run();
+```
+
+### JSON 입력·출력
+
+```bash
+mlr --ijson --ocsv cat example.json
+```
+
+```java
+Mlr.inDir(workingPath)
+	.ijson()
+	.ocsv()
+	.cat()
+	.file("example.json")
+	.run();
+```
+
+### 제자리 갱신 `-I`
+
+```bash
+mlr -I --csv sort -f shape newfile.txt
+```
+
+```java
+Mlr.inDir(tmpDir)
+	.inPlace()
+	.csv()
+	.sort(f("shape"))
+	.file("newfile.txt")
+	.run();
+```
+
+튜토리얼 `put` 예에서 `$y2`를 쓰는 부분은 문서 오타일 가능성이 크다. Miller에서는 제곱을 `$y**2`로 쓴다.
+
+---
+
+## 예시
+
+```java
+import static net.shed.mlrbinder.SortFlags.n;
+import static net.shed.mlrbinder.SortFlags.nr;
+
+import net.shed.mlrbinder.Mlr;
+
+// 권장: 전역 플래그 체인 + 동사 이름 메서드
+String runResult = Mlr.inDir(workingPath)
+	.csv()
+	.sort(n("a"), nr("b"))
+	.file("example.csv")
+	.run();
+
+// CSV 프리셋에서 시작할 때는 정적 Mlr.withCsvPreset()
+String runResult2 = Mlr.withCsvPreset()
+	.workDir(workingPath)
+	.sort(n("a"), nr("b"))
+	.file("example.csv")
+	.run();
+```
+
+### `Mlr`: 전역 플래그 체인 + 동사 이름 인스턴스 메서드(권장)
+
+- **`Mlr.withCsvPreset()`** — 정적 진입: `mlr` + `--csv`(아직 작업 디렉터리 없음; 이어서 `.workDir(…)` / `.file(…)`). 같은 체인에 `--csv`를 하나 더 붙이려면 **`.csv()`**를 다시 호출한다.
+- **전역 플래그 체인(권장):** `.icsv()`, `.opprint()`, **`.csv()`**(`--csv` 추가), `.ocsv()`, `.ijson()`, **`.jsonFlag()`**(`--json`), `.idkvp()`, `.tsv()`, `.oxtab()`, `.ixtab()`, `.c2p()`, `.from("path")`, **`.inPlace()`**(`-I`) 등은 `flag(Flags…)`를 거울로 두지만 **체인 형태를 우선**한다.
+- **동사(권장):** `Verbs`의 각 동사마다 **`Mlr`에 같은 이름의 인스턴스 메서드**가 있다(예: `.uniq()`, `.histogram()`, `.join(…)`). 예외: **`filter`** → **`.filterVerb(…)`**, **`split`** → **`.splitVerb(…)`**. 편의 오버로드: **`.head(n)`** / **`.tail(n)`**, **`.cutFields` / `.cutOrdered` / `.cutExcept`**, **`.stats1("count", "qty")`**, **`.splitBy("shape")`**, **`.putQuiet(…)`**. 위 패턴이 어색할 때만 **`.verb(Mlr.Verbs.foo(…))`**를 쓴다.
+
+`cut`의 `-o` / `-x` / `-f`에는 **`CutFlags`**와 **`.cutOrdered` / `.cutFields`**, 또는 **`.cut(option(…), option(…))`**를 쓴다. `head`/`tail` 개수: **`.head(4)`** / **`.tail(4)`** 또는 **`HeadTail.n(4)`**. `stats1`의 `-a`/`-f`/`-g`: **`StatsFlags`**. `put -q`: **`.putQuiet(…)`**. `split -g`: **`.splitBy("shape")`**. 공통 그룹핑: **`MillerVerbOpts.groupBy("field")`**(예: `head -g`).
+
+**`SortFlags`**는 **`n("field")` / `nr("field")` / `f("field")`**와 **`n()`**(맨 `-n`, `head`용)을 계속 쓰면 된다.
+
+```java
+import static net.shed.mlrbinder.SortFlags.n;
+import static net.shed.mlrbinder.SortFlags.nr;
+
+String runResult = Mlr.withCsvPreset()
+	.workDir(workingPath)
+	.sort(n("a"), nr("b"))
+	.file(new File("example.csv"))
+	.run();
+
+// 같은 튜토리얼 흐름
+String top3 = Mlr.inDir(workingPath)
+	.icsv()
+	.opprint()
+	.sort(nr("index"))
+	.head(3)
+	.file("example.csv")
+	.run();
+```
+
+Miller의 `filter` / `split` 동사는 체인에서 **`.filterVerb(…)`**와 **`.splitVerb(…)`**로 호출한다.
+
+```java
+import static net.shed.mlrbinder.Objective.objective;
+
+Mlr.inDir(workingPath)
+	.csv()
+	.filterVerb(objective("$index > 1"))
+	.file("example.csv")
+	.run();
+```
+
+**`file(File)`**은 `workingPath`가 아직 없을 때 자동으로 맞춘다: 절대 경로 파일이면 부모 디렉터리, 상대 경로 파일이면 `user.dir`. 언제든 `workDir(String)` 또는 `workingPath(String)`으로 덮어쓸 수 있다.
+
+---
+
+## 맺음말
+
+- 저장소·이슈·기여: [https://github.com/bluedskim/mlrBinder](https://github.com/bluedskim/mlrBinder)
 - Miller 문서: [https://miller.readthedocs.io/](https://miller.readthedocs.io/)
 
-배치나 마이크로서비스에서 구분 텍스트를 Miller로만 처리하고 싶다면, 문자열 조립 대신 **체인 API로 의도를 드러내는** 쪽이 유지보수에 이득일 수 있다. JVM에서 `mlr`을 “도구로 두고 코드로 감싸고” 싶다면 한 번 의존성만 추가해 볼 만하다.
+JVM에서 Miller를 **도구로 두고**, 호출은 **체인 API**로 고정하고 싶다면 mlr-binder가 그 역할을 한다. 이 글은 README와 동등한 정보를 한국어 설명으로 덧붙인 형태이니, 버전이 올라가면 저장소 README와 좌표·동작을 함께 확인하면 된다.

--- a/content/posts/tech/mlrBinder-Miller를 Java에서.md
+++ b/content/posts/tech/mlrBinder-Miller를 Java에서.md
@@ -1,0 +1,73 @@
+---
+title: "mlrBinder: Miller(mlr)를 자바에서 fluent API로"
+date: 2026-04-13T12:00:00+09:00
+draft: false
+---
+
+CSV·JSON·TSV·DKVP 같은 구분 텍스트를 다룰 때 [Miller](https://miller.readthedocs.io/)(`mlr`)만큼 손에 익은 도구가 없다면, JVM 쪽 배치·서비스·테스트에서도 같은 워크플로를 쓰고 싶을 때가 있다. 이때 긴 셸 문자열을 이어 붙이거나 `Runtime.exec`에 argv 배열을 손으로 조립하는 대신, **타입과 메서드 이름으로 Miller 호출을 조립**할 수 있게 만든 라이브러리가 [mlrBinder](https://github.com/bluedskim/mlrBinder)다.
+
+## 무엇을 해 주는가
+
+- **실제 `mlr` 프로세스를 실행**한다. JNI로 Miller를 JVM에 묶는 것이 아니라, 조립한 인자 목록으로 `ProcessBuilder`가 `mlr`을 띄운다. 그래서 **업스트림 Miller의 동작**을 그대로 따르면서, 자바 코드만 읽기·리팩터링하기 좋은 형태로 쓸 수 있다.
+- **`Mlr` 체인**, `Flag`, `Verb`, `Option` 등으로 호출을 구성해 **문자열 수프**를 줄이고, IDE에서 이름·시그니처로 검토하기 쉽게 만든다.
+- Miller DSL(`put`, `filter` 등)은 여전히 문자열로 넘기며, **그 부분은 실행 시점에 `mlr`이 검증**한다는 점은 그대로다.
+
+## 언제 쓰면 좋은가
+
+- ETL·데이터 준비 파이프라인에서 대용량 구분 파일을 정렬·절단·조인·집계할 때
+- 스케줄러·워커 같은 **백엔드·배치**에서 반복 가능한 `mlr` 워크플로를 자바로 고정할 때
+- 테스트에서 [Miller in 10 minutes](https://miller.readthedocs.io/en/latest/10min/) 스타일 흐름을 자바로 옮겨 **품질 게이트**로 두고 싶을 때
+- 분석 쪽은 Miller에 익숙하고, 애플리케이션 팀은 JVM만 쓰는 **폴리글랏** 환경에서 공통 의존성 하나로 맞출 때
+
+## 설치
+
+**Java 11 이상**, 시스템에 **`mlr`이 PATH에 있거나** 설정한 경로에서 실행 가능해야 한다. 개발·테스트 기준 Miller 버전은 README 기준 **[mlr 6.17.0](https://github.com/johnkerl/miller/releases/tag/v6.17.0)**이다.
+
+[Maven Central](https://repo1.maven.org/maven2/io/github/bluedskim/mlr-binder/0.2/)에 **`io.github.bluedskim:mlr-binder:0.2`**로 올라와 있다. 패키지 네임스페이스는 **`net.shed.mlrbinder`**다.
+
+Maven:
+
+```xml
+<dependency>
+  <groupId>io.github.bluedskim</groupId>
+  <artifactId>mlr-binder</artifactId>
+  <version>0.2</version>
+</dependency>
+```
+
+Gradle (Kotlin DSL):
+
+```kotlin
+dependencies {
+    implementation("io.github.bluedskim:mlr-binder:0.2")
+}
+```
+
+## 한 줄 맛보기
+
+README에서 권장하는 스타일은 **전역 플래그는 `Mlr` 체인**, 동사(verb)는 **Miller와 같은 이름의 인스턴스 메서드**(`filter`·`split`만 `.filterVerb()` / `.splitVerb()`)다. 예를 들어 CSV를 읽어 `cat`만 돌리는 흐름은 대략 다음과 같이 쓸 수 있다.
+
+```java
+import net.shed.mlrbinder.Mlr;
+
+String out = Mlr.inDir("/path/to/data")
+    .csv()
+    .cat()
+    .file("example.csv")
+    .run();
+```
+
+쉘에서의 `mlr --csv cat example.csv`에 대응한다. `sort`, `cut`, `head`, `put`, `--from`, 파이프에 가까운 두 단계 처리 등은 저장소 README와 테스트(`TenMinTutorialE2eTest` 등)에 **Miller in 10 minutes 튜토리얼과 1:1에 가깝게** 매핑된 예제가 많다.
+
+## 알아두면 좋은 제한
+
+- **네이티브 바인딩이 아니다** — 반드시 외부 `mlr` 바이너리가 필요하다.
+- 잘못된 조합은 **`run()` 시점**에 종료 코드·stderr로 드러난다.
+- 일부 자바 메서드는 Miller CLI 그 자체가 아니라 **자주 쓰는 옵션 묶음(sugar)**이며, Javadoc에 대응하는 Miller CLI가 적혀 있다.
+
+## 더 보기
+
+- 소스·이슈·기여: [https://github.com/bluedskim/mlrBinder](https://github.com/bluedskim/mlrBinder)
+- Miller 문서: [https://miller.readthedocs.io/](https://miller.readthedocs.io/)
+
+배치나 마이크로서비스에서 구분 텍스트를 Miller로만 처리하고 싶다면, 문자열 조립 대신 **체인 API로 의도를 드러내는** 쪽이 유지보수에 이득일 수 있다. JVM에서 `mlr`을 “도구로 두고 코드로 감싸고” 싶다면 한 번 의존성만 추가해 볼 만하다.

--- a/content/posts/tech/mlrBinder-Miller를 Java에서.md
+++ b/content/posts/tech/mlrBinder-Miller를 Java에서.md
@@ -1,27 +1,27 @@
 ---
-title: "mlrBinder: Miller(mlr)를 자바에서 fluent API로 (README 한글판)"
+title: "mlrBinder로 Miller(mlr)를 자바에서 편하게 쓰기"
 date: 2026-04-13T12:00:00+09:00
 draft: false
 ---
 
-이 글은 [mlrBinder](https://github.com/bluedskim/mlrBinder) 저장소 README를 **한국어로 옮긴 것**과 같이 읽으면 된다. 코드 블록 안의 식별자·명령행은 원문과 동일하게 두었다.
+CSV나 JSON, TSV, DKVP처럼 **구분 텍스트**를 다룰 때 [Miller](https://miller.readthedocs.io/)(`mlr`)만큼 손에 잘 맞는 도구도 드물다. 그런데 JVM 쪽 배치나 서비스, 테스트 코드까지 가면 긴 셸 문자열을 이어 붙이거나 `Runtime.exec`에 argv를 손으로 짜는 일이 잦아지고, 나중에 고치기도 부담스럽다.
 
-[Miller](https://miller.readthedocs.io/)(`mlr`)는 CSV, JSON, TSV, DKVP 같은 구분 텍스트를 다루는 강력한 CLI 도구다. **mlr-binder**(저장소 이름: mlrBinder)는 Miller를 **유창한(fluent) 자바 API**로 바꿔 준다. 배치·서비스·테스트에서 손으로 셸 문자열을 짜거나 argv 목록을 복사·붙여넣기 하지 않고도 같은 일을 할 수 있다. **Miller Java Binder**는 실제 `mlr` **프로세스**를 감싸므로, 업스트림 Miller의 의미를 유지하면서 JVM 코드는 읽기 쉽고 리팩터링하기 좋게 남는다.
-
----
-
-## 왜 쓰는가
-
-- **문자열 수프를 줄인다:** 명령을 이어 붙여 IDE에서 이름을 바꾸거나 리뷰하기 어렵게 만들지 말고, `Mlr` 체인과 `Flag`, `Verb`, `Option`으로 조립한다.
-- **실수를 더 일찍 잡는다:** 메서드 이름과 타입이 Miller 구조를 담는다. `put`·`filter` 같은 **Miller DSL 조각**만은 `mlr`이 돌 때까지 검증된다.
-- **빠르게 붙인다:** Maven 또는 Gradle 의존성 하나, `PATH`에 있는 `mlr`(또는 설정한 경로), 그다음 `Mlr.inDir(...).csv().sort(...).file(...).run()`이면 된다. JNI 네이티브 층이나 별도 서비스가 없다.
-- **Maven Central:** 좌표는 **`io.github.bluedskim:mlr-binder`**이며, 예시 버전 디렉터리는 [Central의 0.2 경로](https://repo1.maven.org/maven2/io/github/bluedskim/mlr-binder/0.2/)와 맞는다.
+그럴 때 한번 써 보면 좋은 게 **[mlrBinder](https://github.com/bluedskim/mlrBinder)**다. Maven Central에는 **`mlr-binder`**라는 아티팩트 이름으로 올라가 있고, GitHub에서는 `mlrBinder`로 검색하면 된다. Miller를 **읽기 쉬운 자바 API(플루언트 스타일)**로 호출할 수 있게 해 주며, 내부에서는 우리가 익숙한 **`mlr` 실행 파일**을 그대로 띄운다. 그래서 Miller가 해 주던 일은 그대로 두고, 자바 쪽 코드만 정리되고 리팩터링하기 좋아진다.
 
 ---
 
-## 설치
+## 이런 점이 좋다
 
-**Java 11 이상**이 필요하다. 자바 패키지(타입이 들어 있는 패키지)는 **`net.shed.mlrbinder`**다.
+- **긴 명령 문자열이 줄어든다.** 셸 한 줄을 이어 붙이느라 IDE에서 이름 바꾸기나 리뷰가 힘들어지는 대신, `Mlr` 체인과 `Flag`, `Verb`, `Option`으로 차근차근 조립할 수 있다.
+- **실수를 조금 더 일찍 발견할 수 있다.** 메서드 이름과 타입이 Miller 구조를 담아 주기 때문이다. 다만 `put`·`filter` 같은 **Miller DSL 조각**은 여전히 `mlr`이 돌 때 검증된다는 점만 기억해 두면 된다.
+- **프로젝트에 붙이기 쉽다.** Maven 또는 Gradle 의존성 하나, `PATH`에 있는 `mlr`(또는 직접 지정한 경로), 그다음 `Mlr.inDir(...).csv().sort(...).file(...).run()` 정도면 시작할 수 있다. JNI로 Miller를 JVM에 묶는 방식이 아니라서, 별도 네이티브 빌드나 서비스도 필요 없다.
+- **Maven Central에서 바로 받을 수 있다.** 좌표는 **`io.github.bluedskim:mlr-binder`**이고, 예시로 쓴 **0.2**는 [Central 디렉터리](https://repo1.maven.org/maven2/io/github/bluedskim/mlr-binder/0.2/)에서도 확인할 수 있다.
+
+---
+
+## 설치부터
+
+**Java 11 이상**이면 된다. 라이브러리 타입이 들어 있는 패키지 이름은 **`net.shed.mlrbinder`**다. 아래를 `pom.xml`이나 `build.gradle`에 그대로 넣어 보면 된다.
 
 Maven (`pom.xml`):
 
@@ -51,57 +51,59 @@ dependencies {
 
 ---
 
-## 활용 사례
+## 이런 때에 특히 잘 맞는다
 
-- **데이터 준비·ETL:** JVM 파이프라인 안에서 대용량 구분 파일이나 JSON을 정렬·절단·조인·변형·집계하고, 엔진은 Miller로 둔다.
-- **백엔드·배치 작업:** 스케줄러나 워커에서 반복 가능한 `mlr` 흐름을 돌릴 때, 작업 디렉터리·파일 헬퍼를 쓰고 깨지기 쉬운 `Runtime.exec` 문자열 대신 API를 쓴다.
-- **품질 게이트·픽스처:** 아래의 “Miller in 10 minutes → 자바”처럼 [Miller in 10 minutes](https://miller.readthedocs.io/en/latest/10min/) 스타일 흐름을 테스트에 옮겨, 알려진 Miller 릴리스에 동작을 고정한다.
-- **폴리글랏 팀:** 분석가는 Miller에 익숙하게 두고, 애플리케이션 팀은 같은 동사(verb)를 자바에서 **공유 의존성 하나**로 호출한다.
-
----
-
-## 지원하는 Miller(`mlr`) 버전
-
-이 라이브러리는 Miller **[`mlr` 6.17.0](https://github.com/johnkerl/miller/releases/tag/v6.17.0)**에 맞춰 개발·테스트된다. `PATH`에 그 버전을 설치하거나, 다른 릴리스를 쓸 때는 동작을 직접 확인하는 것이 좋다.
-
-**바인더 전용 “설탕(sugar)”:** 일부 `Mlr` 메서드는 흔한 Miller 동사 옵션을 한 번에 묶는다(예: `uniqCountBy` → `uniq -c -g …`). 이런 **자바 이름은 Miller CLI 기능이 아니다.** 자식 프로세스는 항상 표준 `mlr`이다. 각 설탕 메서드는 Javadoc에 **대응하는 Miller CLI**를 적어 두었고, `net.shed.mlrbinder` 패키지 요약에는 한 표로 모아 두었다(생성된 Javadoc이나 IDE에서 `Mlr`/패키지 빠른 문서 참고).
-
-**권장 스타일:** 가능하면 **`Mlr` 체인 하나**로 끝낸다. 전역 플래그는 **`Mlr`의 전역 플래그 체인 메서드**(`.icsv()`, `.from("…")` 등)로, 동사는 **Miller 동사와 같은 이름의 인스턴스 메서드**(`.sort(…)`, `.cat()` 등; **`filter`/`split`만** `.filterVerb()` / `.splitVerb()`). `flag(Flags…)` + `verb(Mlr.Verbs…)` 조합은 **꼭 필요할 때만** 쓴다.
+- **데이터 준비·ETL:** JVM 파이프라인 안에서 대용량 구분 파일이나 JSON을 정렬·절단·조인·변형·집계할 때, 처리 엔진은 익숙한 Miller로 두고 호출만 자바로 정리할 수 있다.
+- **백엔드·배치:** 스케줄러나 워커에서 매번 같은 `mlr` 흐름을 돌릴 때, 작업 디렉터리와 파일 경로를 API로 다루면 `Runtime.exec`에 긴 문자열을 넣는 것보다 훨씬 덜 깨지기 쉽다.
+- **테스트·품질 게이트:** 아래 **「Miller in 10 minutes → 자바」** 절처럼 [Miller in 10 minutes](https://miller.readthedocs.io/en/latest/10min/)에 나온 흐름을 테스트 코드로 옮겨 두면, 팀이 정한 Miller 버전과 동작을 함께 고정해 두기 좋다.
+- **팀이 나뉘어 있을 때:** 분석 쪽은 Miller에 익숙하게 두고, 애플리케이션 팀은 자바에서 **같은 동사(verb)를 공유 의존성 하나**로 호출할 수 있다.
 
 ---
 
-## 목표
+## Miller(`mlr`) 버전은 이렇게 맞추면 된다
 
-- **Miller를 부르는 방식:** 긴 명령 문자열을 이어 붙이지 않고, 가능한 한 **자바 메서드와 객체**로 Miller 동작을 표현한다. `Flag`, `Verb`, `Option`과 관련 타입으로 조립한다.
-- **컴파일 타임 검사:** API로 만든 부분(플래그 이름, 동사 이름, 인자 순서 등)은 타입·메서드 시그니처 수준에서 잡을 수 있다. Miller DSL(예: `put` 식)과 필드 이름 유효성은 여전히 **실행 시 `mlr`이 검사**하므로, 컴파일러가 전부를 막을 수는 없다.
-- **Miller 문법을 깊게 몰라도 쓰기:** 위 **권장 스타일**을 따르면 전역 플래그는 **`Mlr` 체인**에, 동사는 **Miller 동사와 같은 이름의 `Mlr` 메서드**에 둔다(예외: `filter` → `.filterVerb()`, `split` → `.splitVerb()`). 내부용·고급 조립에는 **`Mlr.Verbs`** 정적 팩터리도 있다. 세밀한 옵션은 Miller와 같은 인자를 `Flag`, `Objective`, `Option`으로 넘긴다. (`Verb`는 argv 조각일 뿐이니, 가능하면 애플리케이션 코드에서 `new Verb(...)`는 피한다.)
-- **실행:** 내부적으로 `ProcessBuilder`가 조립된 인자 목록으로 `mlr` 프로세스를 띄운다. `mlr`은 `PATH`에 설치되어 실행 가능해야 하며(또는 설정한 경로), **JVM 안에 Miller를 링크하지 않는다.**
+개발과 테스트는 Miller **[`mlr` 6.17.0](https://github.com/johnkerl/miller/releases/tag/v6.17.0)**을 기준으로 돌아간다. 가능하면 `PATH`에 이 버전을 올려 두고 쓰면 가장 편하고, 다른 버전을 쓰신다면 한번 돌려 보시며 동작만 확인해 주시면 된다.
 
----
+**편의를 위한 메서드(바인더 쪽 “설탕”)도 있다.** 예를 들어 `uniqCountBy`처럼 자주 쓰는 옵션 묶음을 한 번에 부를 수 있게 해 두었다(`uniq -c -g …`에 대응). 이런 **자바 쪽 이름이 Miller CLI에 그대로 있는 것은 아니다**는 점만 알아 두면 된다. 실제로 뜨는 건 언제나 익숙한 `mlr` 프로세스다. 각 메서드가 어떤 Miller 명령에 해당하는지는 Javadoc에 적어 두었고, `net.shed.mlrbinder` 패키지 요약에도 표로 모아 두었다. IDE에서 `Mlr`이나 패키지 설명을 펼쳐 보면 바로 이어진다.
 
-## 범위와 한계
-
-- **거의 모든 동사:** Miller 동사마다 팩터리는 `net.shed.mlrbinder.verb.Verbs`에 있고, **`Mlr`의 동사 이름 인스턴스 메서드**와 **`Mlr.Verbs`** 모두 그쪽으로 위임한다. **전역 플래그**는 업스트림 [reference-main-flag-list](https://github.com/johnkerl/miller/blob/main/docs/src/reference-main-flag-list.md)를 따르며 `Flags`의 정적 팩터리로 제공되고, **`Mlr`에 맞는 체인 메서드**도 노출된다(`python3 utils/gen_flags.py`로 재생성). 문서에 없는 플래그는 `Flags.raw("--name")` / `Flags.raw("--name", "value")` 또는 동사 옵션으로 `Flag.flag("...")`를 쓴다. 가변 인자 뒤에 `--`가 오는 `--mfrom` / `--mload` 형태는 `Mlr#mfrom` / `#mload`를 쓴다.
-- **네이티브 바인딩이 아니다:** **외부 `mlr`을 실행**할 뿐, JVM 안에 Miller를 넣지 않는다.
-- **오류가 드러나는 시점:** 잘못된 조합은 `run()` / `run(InputStreamReader)`에서 종료 코드와 stderr로 나타난다.
+**처음 쓰실 때는 이렇게만 기억해 보시면 된다.** 가능하면 **`Mlr` 체인 하나**로 끝낸다. 전역 플래그는 **`.icsv()`, `.from("…")` 같은 체인 메서드**로, 동사는 **Miller와 같은 이름의 메서드**(`.sort(…)`, `.cat()` 등)로 붙인다. **`filter`와 `split`만** 이름이 겹쳐서 `.filterVerb()`, `.splitVerb()`로 불러 준다. `flag(Flags…)`와 `verb(Mlr.Verbs…)` 조합은 **정말 필요할 때**만 꺼내 쓰면 충분하다.
 
 ---
 
-## 테스트(저장소에서)
+## 이 라이브러리가 지향하는 것
+
+- **Miller를 부르는 방식이 정리된다.** 긴 명령 문자열을 이어 붙이기보다, 가능한 한 **자바 메서드와 객체**로 Miller 동작을 표현한다. `Flag`, `Verb`, `Option`과 주변 타입으로 한 줄씩 조립해 가면 된다.
+- **컴파일 단계에서 잡히는 것이 늘어난다.** 플래그 이름, 동사 이름, 인자 순서처럼 API로 만든 부분은 타입과 메서드 시그니처 덕분에 IDE가 도와 준다. 반면 Miller DSL(예: `put` 식)이나 필드 이름이 맞는지는 여전히 **`mlr`이 실행될 때 검사**한다. 그래서 “컴파일만으로 끝”은 아니라는 점만 짚어 두면 된다.
+- **Miller를 아주 깊게 안 써도 시작할 수 있다.** 위에서 말한 **권장 스타일**을 따르면 전역 플래그는 **`Mlr` 체인**에, 동사는 **Miller와 같은 이름의 `Mlr` 메서드**에 두면 된다(`filter` → `.filterVerb()`, `split` → `.splitVerb()`). 더 세밀하게 조립하고 싶을 때는 **`Mlr.Verbs`** 정적 팩터리도 있다. Miller와 똑같은 인자를 넘기고 싶다면 `Flag`, `Objective`, `Option`을 쓰면 된다. (`Verb`는 argv 조각이라, 앱 코드에서는 가능하면 `new Verb(...)` 대신 제공되는 팩터리를 쓰는 편이 편하다.)
+- **실행은 익숙한 방식이다.** 내부에서는 `ProcessBuilder`로 조립된 인자 목록을 들고 `mlr` 프로세스를 띄운다. `mlr`은 `PATH`에서 찾거나(또는 설정한 경로), **JVM 안에 Miller를 링크해 넣는 구조는 아니다.**
+
+---
+
+## 미리 알아 두면 좋은 범위
+
+- **Miller가 하는 일 대부분을 따라간다.** 동사마다 팩터리는 `net.shed.mlrbinder.verb.Verbs`에 모여 있고, **`Mlr`의 동사 이름 메서드**와 **`Mlr.Verbs`**가 함께 그쪽을 바라본다. 전역 플래그는 업스트림 [reference-main-flag-list](https://github.com/johnkerl/miller/blob/main/docs/src/reference-main-flag-list.md)를 따라 `Flags`에 정적 팩터리로 있고, **`Mlr` 체인 메서드**로도 같은 내용을 편하게 쓸 수 있게 해 두었다(저장소에서는 `python3 utils/gen_flags.py`로 맞춰 갱신한다). 문서에 아직 없는 플래그가 필요하면 `Flags.raw("--name")` / `Flags.raw("--name", "value")`나 동사 쪽 `Flag.flag("...")`로 넘기면 된다. `--mfrom` / `--mload`처럼 가변 인자 뒤에 `--`가 붙는 형태는 `Mlr#mfrom` / `#mload`를 쓰면 된다.
+- **네이티브로 Miller를 JVM에 붙이는 프로젝트는 아니다.** 말 그대로 **밖에서 `mlr`을 실행**하는 방식이라, 설치와 운영이 단순하다는 대신 `mlr` 바이너리는 꼭 필요하다.
+- **일부 오류는 실행 직전에 보인다.** 조합이 어긋나면 `run()`이나 `run(InputStreamReader)`에서 종료 코드와 stderr로 알려 준다.
+
+---
+
+## 저장소를 클론해 보신다면
+
+테스트는 Gradle 한 줄이면 된다.
 
 ```bash
 ./gradlew :lib:test
 ```
 
-- 리포트: `lib/build/reports/tests/test/index.html`, 커버리지: `lib/build/jacocoHtml/index.html` ([Jacoco](https://docs.gradle.org/current/userguide/jacoco_plugin.html))
+돌린 뒤에는 `lib/build/reports/tests/test/index.html`에서 결과를, `lib/build/jacocoHtml/index.html`에서 커버리지를 볼 수 있다([Jacoco](https://docs.gradle.org/current/userguide/jacoco_plugin.html)).
 
 ---
 
-## Miller in 10 minutes → 자바
+## Miller in 10 minutes → 자바로 옮기기
 
-[Miller in 10 minutes](https://miller.readthedocs.io/en/latest/10min/)에 나오는 `mlr` 호출이 이 라이브러리에서 어떻게 대응하는지 정리한다. **아래 자바 예는 모두 권장 스타일**을 쓴다: **`Mlr.inDir(…)`**로 시작하고 필요하면 **`.csv()`**(`--csv`), 또는 정적 **`Mlr.withCsvPreset()`**(`mlr` + `--csv`를 먼저 두고 `workDir`/파일을 이어 붙임). 전역 플래그는 **`Mlr`에 체인**하고, 동사는 **이름이 같은 인스턴스 메서드**(`filter`/`split` → `.filterVerb` / `.splitVerb`). 같은 체인에 `--csv`를 또 붙이려면 **`.csv()`**를 다시 호출한다. **동사 옵션**은 `SortFlags`의 `f` / `n` / `nr`, `import static …Flag.flag`와 `flag("-f").objective("…")`, `option` / `objective` 등을 쓴다. 동사를 여러 개 이으면 `run()` argv에 **`then`이 자동 삽입**된다.
+[Miller in 10 minutes](https://miller.readthedocs.io/en/latest/10min/)에 나오는 `mlr` 한 줄이 자바에서는 어떻게 보이는지, 아래에서 차례로 맞춰 보았다. **자바 예제는 모두 같은 권장 스타일**을 따른다: **`Mlr.inDir(…)`**로 시작하고 CSV가 필요하면 **`.csv()`**(`--csv`), 아니면 정적 **`Mlr.withCsvPreset()`**으로 `mlr`과 `--csv`를 먼저 깔고 `workDir`과 파일을 이어 붙인다. 전역 플래그는 **`Mlr`에 체인**하고, 동사는 **이름이 같은 메서드**로 붙인다(`filter`/`split`만 `.filterVerb` / `.splitVerb`). 같은 체인에 `--csv`를 한 번 더 넣고 싶으면 **`.csv()`**를 또 호출하면 된다. **동사 옵션**은 `SortFlags`의 `f` / `n` / `nr`, `import static …Flag.flag`와 `flag("-f").objective("…")`, `option` / `objective` 같은 도우미를 쓰면 된다. 동사를 여러 개 이으면 `run()`이 만들 argv에 **`then`이 자동으로 들어간다.**
 
-실제 코드에서는 필요한 것만 고르면 된다. 아래는 공통으로 자주 쓰는 import 예시다.
+실제 프로젝트에서는 필요한 import만 골라 쓰시면 된다. 자주 함께 등장하는 묶음은 대략 이렇다.
 
 ```java
 import static net.shed.mlrbinder.Flag.flag;
@@ -114,7 +116,7 @@ import static net.shed.mlrbinder.verb.Option.option;
 import net.shed.mlrbinder.Mlr;
 ```
 
-더 많은 패턴은 `TenMinTutorialE2eTest`, `TenMinTutorialFormatsE2eTest`(튜토리얼의 CSV/JSON/DKVP/TSV 형식 절), `lib/src/test/resources/10min/`을 보라.
+더 많은 패턴은 저장소의 `TenMinTutorialE2eTest`, `TenMinTutorialFormatsE2eTest`(튜토리얼의 CSV/JSON/DKVP/TSV 형식 절), `lib/src/test/resources/10min/`을 둘러보시면 그대로 따라가기 쉽다.
 
 ### 입출력 플래그와 `cat`
 
@@ -314,7 +316,7 @@ Mlr.inDir(workingPath)
 	.run();
 ```
 
-튜토리얼의 **셸 파이프**(`mlr … | mlr …`)는 자바에서는 **`Mlr` 호출 두 번**에 대응한다. 첫 단계 표준 출력을 임시 파일로 받으려면 `redirectOutputFile`을 쓰고, 두 번째 단계는 그 디렉터리에서 파일만으로 돌린다(표준 입력 없음).
+튜토리얼에 나오는 **셸 파이프**(`mlr … | mlr …`)는 자바에서는 **`Mlr`를 두 번** 부르는 그림에 가깝다. 첫 단계 표준 출력을 임시 파일로 받고 싶다면 `redirectOutputFile`을 쓰면 되고, 두 번째 단계는 그 디렉터리에서 파일만 넘겨 돌리면 된다(표준 입력은 쓰지 않는다).
 
 ```bash
 mlr --csv sort -nr index example.csv | mlr --icsv --opprint head -n 3
@@ -419,11 +421,13 @@ Mlr.inDir(tmpDir)
 	.run();
 ```
 
-튜토리얼 `put` 예에서 `$y2`를 쓰는 부분은 문서 오타일 가능성이 크다. Miller에서는 제곱을 `$y**2`로 쓴다.
+튜토리얼 `put` 예에 `$y2`가 나오는 부분은 문서 오타일 수 있다. Miller에서는 제곱을 `$y**2`로 쓰는 편이 맞다.
 
 ---
 
-## 예시
+## 짧은 예제로 감 잡기
+
+아래 두 덩어리만 복사해 IDE에 붙여 보셔도, “아, 이렇게 읽히는구나” 하는 감이 바로 올 것이다.
 
 ```java
 import static net.shed.mlrbinder.SortFlags.n;
@@ -431,14 +435,14 @@ import static net.shed.mlrbinder.SortFlags.nr;
 
 import net.shed.mlrbinder.Mlr;
 
-// 권장: 전역 플래그 체인 + 동사 이름 메서드
+// 전역 플래그는 체인에, 동사는 이름 그대로
 String runResult = Mlr.inDir(workingPath)
 	.csv()
 	.sort(n("a"), nr("b"))
 	.file("example.csv")
 	.run();
 
-// CSV 프리셋에서 시작할 때는 정적 Mlr.withCsvPreset()
+// 처음부터 CSV 전제로 시작하고 싶다면 정적 메서드
 String runResult2 = Mlr.withCsvPreset()
 	.workDir(workingPath)
 	.sort(n("a"), nr("b"))
@@ -446,15 +450,15 @@ String runResult2 = Mlr.withCsvPreset()
 	.run();
 ```
 
-### `Mlr`: 전역 플래그 체인 + 동사 이름 인스턴스 메서드(권장)
+### `Mlr`로 체인 짜는 요령(권장 스타일)
 
-- **`Mlr.withCsvPreset()`** — 정적 진입: `mlr` + `--csv`(아직 작업 디렉터리 없음; 이어서 `.workDir(…)` / `.file(…)`). 같은 체인에 `--csv`를 하나 더 붙이려면 **`.csv()`**를 다시 호출한다.
-- **전역 플래그 체인(권장):** `.icsv()`, `.opprint()`, **`.csv()`**(`--csv` 추가), `.ocsv()`, `.ijson()`, **`.jsonFlag()`**(`--json`), `.idkvp()`, `.tsv()`, `.oxtab()`, `.ixtab()`, `.c2p()`, `.from("path")`, **`.inPlace()`**(`-I`) 등은 `flag(Flags…)`를 거울로 두지만 **체인 형태를 우선**한다.
-- **동사(권장):** `Verbs`의 각 동사마다 **`Mlr`에 같은 이름의 인스턴스 메서드**가 있다(예: `.uniq()`, `.histogram()`, `.join(…)`). 예외: **`filter`** → **`.filterVerb(…)`**, **`split`** → **`.splitVerb(…)`**. 편의 오버로드: **`.head(n)`** / **`.tail(n)`**, **`.cutFields` / `.cutOrdered` / `.cutExcept`**, **`.stats1("count", "qty")`**, **`.splitBy("shape")`**, **`.putQuiet(…)`**. 위 패턴이 어색할 때만 **`.verb(Mlr.Verbs.foo(…))`**를 쓴다.
+- **`Mlr.withCsvPreset()`**으로 시작하면 이미 `mlr`과 `--csv`가 깔린 상태다. 아직 작업 디렉터리는 비어 있으니 이어서 `.workDir(…)`나 `.file(…)`을 붙이면 된다. 같은 체인에 `--csv`를 한 번 더 넣고 싶다면 **`.csv()`**를 또 호출하면 된다.
+- **전역 플래그**는 `.icsv()`, `.opprint()`, **`.csv()`**, `.ocsv()`, `.ijson()`, **`.jsonFlag()`**(`--json`), `.idkvp()`, `.tsv()`, `.oxtab()`, `.ixtab()`, `.c2p()`, `.from("path")`, **`.inPlace()`**(`-I`)처럼 체인 메서드로 붙이는 쪽이 읽기 좋다. `flag(Flags…)`로도 같은 일을 할 수 있지만, 평소에는 **체인을 먼저** 쓰면 된다.
+- **동사**는 Miller와 같은 이름의 메서드가 대부분이다(예: `.uniq()`, `.histogram()`, `.join(…)`). 예외는 **`filter`** → **`.filterVerb(…)`**, **`split`** → **`.splitVerb(…)`**뿐이다. 자주 쓰는 조합은 **`.head(n)`**, **`.tail(n)`**, **`.cutFields` / `.cutOrdered` / `.cutExcept`**, **`.stats1("count", "qty")`**, **`.splitBy("shape")`**, **`.putQuiet(…)`**처럼 짧게도 부를 수 있다. 위 패턴으로 부족할 때만 **`.verb(Mlr.Verbs.foo(…))`**를 꺼내면 된다.
 
-`cut`의 `-o` / `-x` / `-f`에는 **`CutFlags`**와 **`.cutOrdered` / `.cutFields`**, 또는 **`.cut(option(…), option(…))`**를 쓴다. `head`/`tail` 개수: **`.head(4)`** / **`.tail(4)`** 또는 **`HeadTail.n(4)`**. `stats1`의 `-a`/`-f`/`-g`: **`StatsFlags`**. `put -q`: **`.putQuiet(…)`**. `split -g`: **`.splitBy("shape")`**. 공통 그룹핑: **`MillerVerbOpts.groupBy("field")`**(예: `head -g`).
+`cut`의 `-o` / `-x` / `-f`는 **`CutFlags`**와 **`.cutOrdered` / `.cutFields`**, 또는 **`.cut(option(…), option(…))`**로 맞추면 된다. `head`/`tail` 개수는 **`.head(4)`** / **`.tail(4)`** 또는 **`HeadTail.n(4)`**. `stats1`의 `-a`/`-f`/`-g`는 **`StatsFlags`**. `put -q`는 **`.putQuiet(…)`**. `split -g`는 **`.splitBy("shape")`**. 여러 동사에서 같이 쓰는 그룹핑은 **`MillerVerbOpts.groupBy("field")`**(예: `head -g`)를 참고하면 된다.
 
-**`SortFlags`**는 **`n("field")` / `nr("field")` / `f("field")`**와 **`n()`**(맨 `-n`, `head`용)을 계속 쓰면 된다.
+**`SortFlags`**는 **`n("field")`**, **`nr("field")`**, **`f("field")`**, 그리고 `head`용 맨 `-n`인 **`n()`**을 계속 쓰면 된다.
 
 ```java
 import static net.shed.mlrbinder.SortFlags.n;
@@ -466,7 +470,7 @@ String runResult = Mlr.withCsvPreset()
 	.file(new File("example.csv"))
 	.run();
 
-// 같은 튜토리얼 흐름
+// 튜토리얼에 나오는 흐름과 같은 그림
 String top3 = Mlr.inDir(workingPath)
 	.icsv()
 	.opprint()
@@ -476,7 +480,7 @@ String top3 = Mlr.inDir(workingPath)
 	.run();
 ```
 
-Miller의 `filter` / `split` 동사는 체인에서 **`.filterVerb(…)`**와 **`.splitVerb(…)`**로 호출한다.
+Miller의 `filter`와 `split`은 자바 예약어와 겹치니, 체인에서는 **`.filterVerb(…)`**와 **`.splitVerb(…)`**로 부르면 된다.
 
 ```java
 import static net.shed.mlrbinder.Objective.objective;
@@ -488,13 +492,13 @@ Mlr.inDir(workingPath)
 	.run();
 ```
 
-**`file(File)`**은 `workingPath`가 아직 없을 때 자동으로 맞춘다: 절대 경로 파일이면 부모 디렉터리, 상대 경로 파일이면 `user.dir`. 언제든 `workDir(String)` 또는 `workingPath(String)`으로 덮어쓸 수 있다.
+**`file(File)`**은 작업 디렉터리가 비어 있을 때 알아서 채워 준다. 절대 경로 파일이면 부모 폴더를, 상대 경로면 `user.dir`을 기준으로 잡는다. 마음에 안 들면 언제든 `workDir(String)`이나 `workingPath(String)`으로 덮어쓰면 된다.
 
 ---
 
-## 맺음말
+## 더 알아보기
 
-- 저장소·이슈·기여: [https://github.com/bluedskim/mlrBinder](https://github.com/bluedskim/mlrBinder)
-- Miller 문서: [https://miller.readthedocs.io/](https://miller.readthedocs.io/)
+- **소스와 이슈, 기여:** [https://github.com/bluedskim/mlrBinder](https://github.com/bluedskim/mlrBinder)
+- **Miller 공식 문서:** [https://miller.readthedocs.io/](https://miller.readthedocs.io/)
 
-JVM에서 Miller를 **도구로 두고**, 호출은 **체인 API**로 고정하고 싶다면 mlr-binder가 그 역할을 한다. 이 글은 README와 동등한 정보를 한국어 설명으로 덧붙인 형태이니, 버전이 올라가면 저장소 README와 좌표·동작을 함께 확인하면 된다.
+Miller는 그대로 두고 JVM 쪽만 **읽기 좋은 체인 API**로 감싸고 싶다면 mlr-binder를 한번 의존성에 넣어 보시길 권한다. 버전이나 좌표는 시간이 지나면 바뀔 수 있으니, 쓰시기 직전에 GitHub README와 Maven Central을 함께 확인해 주시면 가장 안전하다.

--- a/content/posts/tech/mlrBinder-Miller를 Java에서.md
+++ b/content/posts/tech/mlrBinder-Miller를 Java에서.md
@@ -1,27 +1,31 @@
 ---
-title: "mlrBinder로 Miller(mlr)를 자바에서 편하게 쓰기"
+title: "mlrBinder를 소개합니다 — Miller를 자바에서 부르고 싶어서 만들었습니다"
 date: 2026-04-13T12:00:00+09:00
 draft: false
+description: "mlrBinder 저자가 직접 쓴 소개글. Miller(mlr)를 JVM에서 문자열 지옥 없이 쓰게 해 주는 라이브러리입니다."
 ---
 
-CSV나 JSON, TSV, DKVP처럼 **구분 텍스트**를 다룰 때 [Miller](https://miller.readthedocs.io/)(`mlr`)만큼 손에 잘 맞는 도구도 드물다. 그런데 JVM 쪽 배치나 서비스, 테스트 코드까지 가면 긴 셸 문자열을 이어 붙이거나 `Runtime.exec`에 argv를 손으로 짜는 일이 잦아지고, 나중에 고치기도 부담스럽다.
-
-그럴 때 한번 써 보면 좋은 게 **[mlrBinder](https://github.com/bluedskim/mlrBinder)**다. Maven Central에는 **`mlr-binder`**라는 아티팩트 이름으로 올라가 있고, GitHub에서는 `mlrBinder`로 검색하면 된다. Miller를 **읽기 쉬운 자바 API(플루언트 스타일)**로 호출할 수 있게 해 주며, 내부에서는 우리가 익숙한 **`mlr` 실행 파일**을 그대로 띄운다. 그래서 Miller가 해 주던 일은 그대로 두고, 자바 쪽 코드만 정리되고 리팩터링하기 좋아진다.
-
----
-
-## 이런 점이 좋다
-
-- **긴 명령 문자열이 줄어든다.** 셸 한 줄을 이어 붙이느라 IDE에서 이름 바꾸기나 리뷰가 힘들어지는 대신, `Mlr` 체인과 `Flag`, `Verb`, `Option`으로 차근차근 조립할 수 있다.
-- **실수를 조금 더 일찍 발견할 수 있다.** 메서드 이름과 타입이 Miller 구조를 담아 주기 때문이다. 다만 `put`·`filter` 같은 **Miller DSL 조각**은 여전히 `mlr`이 돌 때 검증된다는 점만 기억해 두면 된다.
-- **프로젝트에 붙이기 쉽다.** Maven 또는 Gradle 의존성 하나, `PATH`에 있는 `mlr`(또는 직접 지정한 경로), 그다음 `Mlr.inDir(...).csv().sort(...).file(...).run()` 정도면 시작할 수 있다. JNI로 Miller를 JVM에 묶는 방식이 아니라서, 별도 네이티브 빌드나 서비스도 필요 없다.
-- **Maven Central에서 바로 받을 수 있다.** 좌표는 **`io.github.bluedskim:mlr-binder`**이고, 예시로 쓴 **0.2**는 [Central 디렉터리](https://repo1.maven.org/maven2/io/github/bluedskim/mlr-binder/0.2/)에서도 확인할 수 있다.
+**먼저 밝힙니다.** [mlrBinder](https://github.com/bluedskim/mlrBinder)는 **제가 만들고 있는 프로젝트**입니다. 이 글은 남이 쓴 리뷰가 아니라, **저자 입장에서** “왜 만들었는지, 어떻게 쓰면 좋은지”를 블로그 독자분께 직접 전하려고 쓴 홍보 겸 안내 글입니다. (이 블로그 설정상 이름은 Dennis로 나가고, GitHub·Maven Central에는 `bluedskim`으로 올라가 있습니다.)
 
 ---
 
-## 설치부터
+CSV·JSON·TSV·DKVP처럼 **구분 텍스트**를 다룰 때 [Miller](https://miller.readthedocs.io/)(`mlr`)는 정말 잘 빠진 도구라고 생각합니다. 저도 터미널에서는 거의 손이 가요. 그런데 같은 일을 **자바 배치나 서비스, 테스트**로 옮기면 이야기가 달라집니다. 긴 셸 한 줄을 문자열로 이어 붙이거나, `Runtime.exec`에 argv를 손으로 짜다 보면 **나중에 고치기 무섭고**, 코드 리뷰에서도 한눈에 안 들어옵니다.
 
-**Java 11 이상**이면 된다. 라이브러리 타입이 들어 있는 패키지 이름은 **`net.shed.mlrbinder`**다. 아래를 `pom.xml`이나 `build.gradle`에 그대로 넣어 보면 된다.
+그래서 **“Miller는 그대로 두고, 호출만 자바답게”** 하고 싶어서 시작한 게 **mlr-binder**(Maven 아티팩트 이름)이고, 저장소 이름은 **mlrBinder**로 두었습니다. 내부에서는 익숙한 **`mlr` 실행 파일**을 `ProcessBuilder`로 띄우고, 겉에서는 **`Mlr` 체인**으로 읽기 쉽게 조립할 수 있게 했습니다. JNI로 Miller를 JVM에 붙이는 방식이 아니라서, **의존성 하나 + PATH에 mlr**이면 시작할 수 있다는 것도 제가 중요하게 본 포인트입니다.
+
+---
+
+## 제가 이렇게 설계해 둔 이유
+
+- **명령 문자열을 덜 쓰게 하고 싶었습니다.** `Mlr` 체인과 `Flag`, `Verb`, `Option`으로 조립하면 IDE에서 이름 바꾸기·점프·리뷰가 훨씬 편해집니다.
+- **컴파일러와 IDE가 도울 수 있는 부분은 최대한 끌어올리고 싶었습니다.** 플래그 이름, 동사 이름, 인자 순서 같은 건 타입과 시그니처에 담겼습니다. 반대로 `put`·`filter` 식처럼 **Miller DSL**은 여전히 `mlr`이 실행될 때 검증된다는 점은 솔직히 말씀드릴게요. “전부 컴파일 타임”은 아닙니다.
+- **프로젝트에 얹기 쉽게** Maven Central에 **`io.github.bluedskim:mlr-binder`**로 올려 두었습니다. 아래 예시 버전 **0.2**는 [Central 디렉터리](https://repo1.maven.org/maven2/io/github/bluedskim/mlr-binder/0.2/)에서도 확인하실 수 있습니다.
+
+---
+
+## 설치 — 이렇게만 넣어 보세요
+
+**Java 11 이상**이면 됩니다. 타입이 들어 있는 패키지는 **`net.shed.mlrbinder`**입니다.
 
 Maven (`pom.xml`):
 
@@ -51,59 +55,59 @@ dependencies {
 
 ---
 
-## 이런 때에 특히 잘 맞는다
+## 제가 염두에 둔 사용처
 
-- **데이터 준비·ETL:** JVM 파이프라인 안에서 대용량 구분 파일이나 JSON을 정렬·절단·조인·변형·집계할 때, 처리 엔진은 익숙한 Miller로 두고 호출만 자바로 정리할 수 있다.
-- **백엔드·배치:** 스케줄러나 워커에서 매번 같은 `mlr` 흐름을 돌릴 때, 작업 디렉터리와 파일 경로를 API로 다루면 `Runtime.exec`에 긴 문자열을 넣는 것보다 훨씬 덜 깨지기 쉽다.
-- **테스트·품질 게이트:** 아래 **「Miller in 10 minutes → 자바」** 절처럼 [Miller in 10 minutes](https://miller.readthedocs.io/en/latest/10min/)에 나온 흐름을 테스트 코드로 옮겨 두면, 팀이 정한 Miller 버전과 동작을 함께 고정해 두기 좋다.
-- **팀이 나뉘어 있을 때:** 분석 쪽은 Miller에 익숙하게 두고, 애플리케이션 팀은 자바에서 **같은 동사(verb)를 공유 의존성 하나**로 호출할 수 있다.
-
----
-
-## Miller(`mlr`) 버전은 이렇게 맞추면 된다
-
-개발과 테스트는 Miller **[`mlr` 6.17.0](https://github.com/johnkerl/miller/releases/tag/v6.17.0)**을 기준으로 돌아간다. 가능하면 `PATH`에 이 버전을 올려 두고 쓰면 가장 편하고, 다른 버전을 쓰신다면 한번 돌려 보시며 동작만 확인해 주시면 된다.
-
-**편의를 위한 메서드(바인더 쪽 “설탕”)도 있다.** 예를 들어 `uniqCountBy`처럼 자주 쓰는 옵션 묶음을 한 번에 부를 수 있게 해 두었다(`uniq -c -g …`에 대응). 이런 **자바 쪽 이름이 Miller CLI에 그대로 있는 것은 아니다**는 점만 알아 두면 된다. 실제로 뜨는 건 언제나 익숙한 `mlr` 프로세스다. 각 메서드가 어떤 Miller 명령에 해당하는지는 Javadoc에 적어 두었고, `net.shed.mlrbinder` 패키지 요약에도 표로 모아 두었다. IDE에서 `Mlr`이나 패키지 설명을 펼쳐 보면 바로 이어진다.
-
-**처음 쓰실 때는 이렇게만 기억해 보시면 된다.** 가능하면 **`Mlr` 체인 하나**로 끝낸다. 전역 플래그는 **`.icsv()`, `.from("…")` 같은 체인 메서드**로, 동사는 **Miller와 같은 이름의 메서드**(`.sort(…)`, `.cat()` 등)로 붙인다. **`filter`와 `split`만** 이름이 겹쳐서 `.filterVerb()`, `.splitVerb()`로 불러 준다. `flag(Flags…)`와 `verb(Mlr.Verbs…)` 조합은 **정말 필요할 때**만 꺼내 쓰면 충분하다.
+- **데이터 준비·ETL:** JVM 파이프라인 안에서 정렬·절단·조인·변형·집계를 하되, 엔진은 Miller로 두고 싶을 때.
+- **백엔드·배치:** 스케줄러·워커에서 같은 `mlr` 흐름을 반복할 때, `Runtime.exec`에 긴 문자열을 박는 대신 작업 디렉터리와 파일을 API로 다루고 싶을 때.
+- **테스트·품질 게이트:** 아래 **「Miller in 10 minutes → 자바」**처럼 [Miller in 10 minutes](https://miller.readthedocs.io/en/latest/10min/) 흐름을 테스트에 옮겨, 팀이 고른 Miller 버전과 함께 동작을 고정하고 싶을 때.
+- **팀이 갈라져 있을 때:** 분석 쪽은 Miller에 익숙하게 두고, 애플리케이션 쪽은 **같은 동사(verb)를 자바 의존성 하나**로 맞추고 싶을 때.
 
 ---
 
-## 이 라이브러리가 지향하는 것
+## Miller 버전과 제가 권하는 쓰는 법
 
-- **Miller를 부르는 방식이 정리된다.** 긴 명령 문자열을 이어 붙이기보다, 가능한 한 **자바 메서드와 객체**로 Miller 동작을 표현한다. `Flag`, `Verb`, `Option`과 주변 타입으로 한 줄씩 조립해 가면 된다.
-- **컴파일 단계에서 잡히는 것이 늘어난다.** 플래그 이름, 동사 이름, 인자 순서처럼 API로 만든 부분은 타입과 메서드 시그니처 덕분에 IDE가 도와 준다. 반면 Miller DSL(예: `put` 식)이나 필드 이름이 맞는지는 여전히 **`mlr`이 실행될 때 검사**한다. 그래서 “컴파일만으로 끝”은 아니라는 점만 짚어 두면 된다.
-- **Miller를 아주 깊게 안 써도 시작할 수 있다.** 위에서 말한 **권장 스타일**을 따르면 전역 플래그는 **`Mlr` 체인**에, 동사는 **Miller와 같은 이름의 `Mlr` 메서드**에 두면 된다(`filter` → `.filterVerb()`, `split` → `.splitVerb()`). 더 세밀하게 조립하고 싶을 때는 **`Mlr.Verbs`** 정적 팩터리도 있다. Miller와 똑같은 인자를 넘기고 싶다면 `Flag`, `Objective`, `Option`을 쓰면 된다. (`Verb`는 argv 조각이라, 앱 코드에서는 가능하면 `new Verb(...)` 대신 제공되는 팩터리를 쓰는 편이 편하다.)
-- **실행은 익숙한 방식이다.** 내부에서는 `ProcessBuilder`로 조립된 인자 목록을 들고 `mlr` 프로세스를 띄운다. `mlr`은 `PATH`에서 찾거나(또는 설정한 경로), **JVM 안에 Miller를 링크해 넣는 구조는 아니다.**
+저는 개발·테스트를 Miller **[`mlr` 6.17.0](https://github.com/johnkerl/miller/releases/tag/v6.17.0)**에 맞춰 돌리고 있습니다. 가능하면 `PATH`에 이 버전을 두시고 쓰시면 제가 확인한 것과 가장 가깝습니다. 다른 버전은 한번 돌려 보시고 차이만 감안해 주시면 됩니다.
 
----
+**“설탕” 메서드**도 넣어 두었습니다. 예를 들어 `uniqCountBy`는 자주 쓰는 옵션 묶음을 한 번에 부르게 해 두었고(`uniq -c -g …`에 대응), 이런 **자바 이름이 Miller CLI에 그대로 있는 것은 아닙니다.** 실제 프로세스는 항상 표준 `mlr`입니다. 각 메서드가 어떤 Miller 명령과 같은지는 **Javadoc**에 적어 두었고, `net.shed.mlrbinder` 패키지 요약에도 표로 모아 두었으니 IDE에서 `Mlr`만 펼쳐 보셔도 이어집니다.
 
-## 미리 알아 두면 좋은 범위
-
-- **Miller가 하는 일 대부분을 따라간다.** 동사마다 팩터리는 `net.shed.mlrbinder.verb.Verbs`에 모여 있고, **`Mlr`의 동사 이름 메서드**와 **`Mlr.Verbs`**가 함께 그쪽을 바라본다. 전역 플래그는 업스트림 [reference-main-flag-list](https://github.com/johnkerl/miller/blob/main/docs/src/reference-main-flag-list.md)를 따라 `Flags`에 정적 팩터리로 있고, **`Mlr` 체인 메서드**로도 같은 내용을 편하게 쓸 수 있게 해 두었다(저장소에서는 `python3 utils/gen_flags.py`로 맞춰 갱신한다). 문서에 아직 없는 플래그가 필요하면 `Flags.raw("--name")` / `Flags.raw("--name", "value")`나 동사 쪽 `Flag.flag("...")`로 넘기면 된다. `--mfrom` / `--mload`처럼 가변 인자 뒤에 `--`가 붙는 형태는 `Mlr#mfrom` / `#mload`를 쓰면 된다.
-- **네이티브로 Miller를 JVM에 붙이는 프로젝트는 아니다.** 말 그대로 **밖에서 `mlr`을 실행**하는 방식이라, 설치와 운영이 단순하다는 대신 `mlr` 바이너리는 꼭 필요하다.
-- **일부 오류는 실행 직전에 보인다.** 조합이 어긋나면 `run()`이나 `run(InputStreamReader)`에서 종료 코드와 stderr로 알려 준다.
+**처음 쓰실 때는** 가능하면 **`Mlr` 체인 하나**로 끝내 보세요. 전역 플래그는 **`.icsv()`, `.from("…")` 같은 체인 메서드**로, 동사는 **Miller와 같은 이름의 메서드**(`.sort(…)`, `.cat()` 등)로 붙입니다. **`filter`와 `split`만** 자바 쪽 이름이 겹쳐서 `.filterVerb()`, `.splitVerb()`입니다. `flag(Flags…)`와 `verb(Mlr.Verbs…)`는 **정말 필요할 때**만 쓰셔도 충분합니다.
 
 ---
 
-## 저장소를 클론해 보신다면
+## 제가 이 라이브러리에 바라 둔 것
 
-테스트는 Gradle 한 줄이면 된다.
+- **Miller 호출이 코드로 읽히게** — 긴 문자열 이어붙이기보다 `Flag`, `Verb`, `Option`으로 조립하는 쪽을 표준으로 삼았습니다.
+- **API로 만든 부분은 타입이 잡게** — 반대로 Miller DSL이나 필드 이름은 **`mlr` 실행 시** 검사된다는 점은 README에도 적어 둔 그대로입니다.
+- **Miller를 아주 깊게 안 써도 시작할 수 있게** — 권장 스타일만 따르면 전역 플래그는 **`Mlr` 체인**, 동사는 **이름이 같은 `Mlr` 메서드**로 갑니다. 더 세밀하게는 **`Mlr.Verbs`**와 `Flag`, `Objective`, `Option`을 쓰시면 됩니다. (`Verb`는 argv 조각이라, 앱 코드에서는 가능하면 `new Verb(...)` 대신 팩터리를 쓰는 편을 권합니다.)
+- **실행은 단순하게** — `ProcessBuilder`로 `mlr`을 띄웁니다. JVM 안에 Miller를 링크하는 구조는 아닙니다.
+
+---
+
+## 솔직히 말씀드리는 범위와 한계
+
+- **거의 모든 Miller 동사**를 따라가도록 `net.shed.mlrbinder.verb.Verbs`에 팩터리를 모아 두었고, **`Mlr`의 동사 이름 메서드**와 **`Mlr.Verbs`**가 함께 그쪽을 바라봅니다. 전역 플래그는 업스트림 [reference-main-flag-list](https://github.com/johnkerl/miller/blob/main/docs/src/reference-main-flag-list.md)를 따라 `Flags`에 두었고, **`Mlr` 체인 메서드**로도 같은 내용을 쓸 수 있게 맞춰 두었습니다(저장소에서는 `python3 utils/gen_flags.py`로 갱신). 문서에 없는 플래그는 `Flags.raw("--name")` / `Flags.raw("--name", "value")`나 `Flag.flag("...")`로 넘기실 수 있습니다. `--mfrom` / `--mload`처럼 가변 인자 뒤에 `--`가 오는 형태는 `Mlr#mfrom` / `#mload`를 쓰시면 됩니다.
+- **네이티브 바인딩은 아닙니다.** 밖에서 `mlr`을 실행하는 방식이라, **바이너리는 꼭 필요**합니다. 대신 배포와 운영 스토리는 단순해집니다.
+- **일부 오류는 `run()` 직전**에 종료 코드와 stderr로 드러납니다. 그 점은 미리 알아 두시면 덜 당황하실 거예요.
+
+---
+
+## 저장소를 클론해 주신다면
+
+제가 CI에서도 돌리는 테스트는 이 한 줄입니다.
 
 ```bash
 ./gradlew :lib:test
 ```
 
-돌린 뒤에는 `lib/build/reports/tests/test/index.html`에서 결과를, `lib/build/jacocoHtml/index.html`에서 커버리지를 볼 수 있다([Jacoco](https://docs.gradle.org/current/userguide/jacoco_plugin.html)).
+결과는 `lib/build/reports/tests/test/index.html`, 커버리지는 `lib/build/jacocoHtml/index.html`에서 보실 수 있습니다([Jacoco](https://docs.gradle.org/current/userguide/jacoco_plugin.html)).
 
 ---
 
-## Miller in 10 minutes → 자바로 옮기기
+## Miller in 10 minutes → 자바 (README와 같은 매핑)
 
-[Miller in 10 minutes](https://miller.readthedocs.io/en/latest/10min/)에 나오는 `mlr` 한 줄이 자바에서는 어떻게 보이는지, 아래에서 차례로 맞춰 보았다. **자바 예제는 모두 같은 권장 스타일**을 따른다: **`Mlr.inDir(…)`**로 시작하고 CSV가 필요하면 **`.csv()`**(`--csv`), 아니면 정적 **`Mlr.withCsvPreset()`**으로 `mlr`과 `--csv`를 먼저 깔고 `workDir`과 파일을 이어 붙인다. 전역 플래그는 **`Mlr`에 체인**하고, 동사는 **이름이 같은 메서드**로 붙인다(`filter`/`split`만 `.filterVerb` / `.splitVerb`). 같은 체인에 `--csv`를 한 번 더 넣고 싶으면 **`.csv()`**를 또 호출하면 된다. **동사 옵션**은 `SortFlags`의 `f` / `n` / `nr`, `import static …Flag.flag`와 `flag("-f").objective("…")`, `option` / `objective` 같은 도우미를 쓰면 된다. 동사를 여러 개 이으면 `run()`이 만들 argv에 **`then`이 자동으로 들어간다.**
+아래는 [Miller in 10 minutes](https://miller.readthedocs.io/en/latest/10min/)에 나오는 `mlr` 한 줄이 **제가 라이브러리에서 어떻게 보이게 해 두었는지**를, 저장소 README와 같은 순서로 옮겨 둔 부분입니다. **자바 예제는 모두 제가 권하는 스타일**입니다: **`Mlr.inDir(…)`**로 시작하고 CSV가 필요하면 **`.csv()`**, 아니면 **`Mlr.withCsvPreset()`**으로 `mlr` + `--csv`를 먼저 깔고 `workDir`과 파일을 이어 붙입니다. 전역 플래그는 **`Mlr`에 체인**, 동사는 **이름이 같은 메서드**(`filter`/`split`만 `.filterVerb` / `.splitVerb`). `--csv`를 한 번 더 넣고 싶으면 **`.csv()`**를 또 호출하시면 됩니다. 동사 옵션은 `SortFlags`의 `f` / `n` / `nr`, `flag("-f").objective("…")`, `option` / `objective` 등을 쓰시면 되고, 동사를 여러 개 이으면 `run()` argv에 **`then`이 자동으로 들어갑니다.**
 
-실제 프로젝트에서는 필요한 import만 골라 쓰시면 된다. 자주 함께 등장하는 묶음은 대략 이렇다.
+실제 프로젝트에서는 필요한 import만 골라 쓰시면 됩니다. 자주 함께 쓰는 묶음은 대략 이렇습니다.
 
 ```java
 import static net.shed.mlrbinder.Flag.flag;
@@ -116,7 +120,7 @@ import static net.shed.mlrbinder.verb.Option.option;
 import net.shed.mlrbinder.Mlr;
 ```
 
-더 많은 패턴은 저장소의 `TenMinTutorialE2eTest`, `TenMinTutorialFormatsE2eTest`(튜토리얼의 CSV/JSON/DKVP/TSV 형식 절), `lib/src/test/resources/10min/`을 둘러보시면 그대로 따라가기 쉽다.
+더 많은 패턴은 제가 테스트로도 남겨 둔 `TenMinTutorialE2eTest`, `TenMinTutorialFormatsE2eTest`, `lib/src/test/resources/10min/`을 보시면 그대로 따라가기 쉽습니다.
 
 ### 입출력 플래그와 `cat`
 
@@ -147,7 +151,7 @@ Mlr.inDir(workingPath)
 
 ### 파일 형식(CSV, JSON, DKVP, TSV)
 
-튜토리얼 “File formats” 절과 같이, `--csv` / `--json` / `--idkvp` / `--tsv` 등으로 입력 형식을 맞춘다.
+튜토리얼 “File formats” 절과 같이 입력 형식을 맞춥니다.
 
 ```bash
 mlr --csv cat shape.csv
@@ -219,7 +223,7 @@ Mlr.inDir(workingPath)
 	.run();
 ```
 
-### `filter` / `put`(DSL은 그대로 문자열)
+### `filter` / `put`(DSL은 문자열 그대로)
 
 ```bash
 mlr --icsv --opprint filter '$color == "red"' example.csv
@@ -316,7 +320,7 @@ Mlr.inDir(workingPath)
 	.run();
 ```
 
-튜토리얼에 나오는 **셸 파이프**(`mlr … | mlr …`)는 자바에서는 **`Mlr`를 두 번** 부르는 그림에 가깝다. 첫 단계 표준 출력을 임시 파일로 받고 싶다면 `redirectOutputFile`을 쓰면 되고, 두 번째 단계는 그 디렉터리에서 파일만 넘겨 돌리면 된다(표준 입력은 쓰지 않는다).
+셸 파이프(`mlr … | mlr …`)는 자바에서는 **`Mlr`를 두 번** 부르는 그림에 가깝게 매겼습니다. 첫 단계 stdout을 파일로 받고 싶으면 `redirectOutputFile`을 쓰시고, 두 번째는 그 디렉터리에서 파일만 넘기면 됩니다.
 
 ```bash
 mlr --csv sort -nr index example.csv | mlr --icsv --opprint head -n 3
@@ -421,13 +425,13 @@ Mlr.inDir(tmpDir)
 	.run();
 ```
 
-튜토리얼 `put` 예에 `$y2`가 나오는 부분은 문서 오타일 수 있다. Miller에서는 제곱을 `$y**2`로 쓰는 편이 맞다.
+튜토리얼 `put` 예의 `$y2`는 문서 오타일 수 있습니다. Miller에서는 제곱을 `$y**2`로 쓰는 편이 맞습니다.
 
 ---
 
-## 짧은 예제로 감 잡기
+## 짧게 한번 돌려 보고 싶다면
 
-아래 두 덩어리만 복사해 IDE에 붙여 보셔도, “아, 이렇게 읽히는구나” 하는 감이 바로 올 것이다.
+README에도 넣어 둔 그림입니다. IDE에 붙여 보시면 체인이 어떻게 읽히는지 바로 오실 거예요.
 
 ```java
 import static net.shed.mlrbinder.SortFlags.n;
@@ -442,7 +446,7 @@ String runResult = Mlr.inDir(workingPath)
 	.file("example.csv")
 	.run();
 
-// 처음부터 CSV 전제로 시작하고 싶다면 정적 메서드
+// 처음부터 CSV 전제로 시작할 때
 String runResult2 = Mlr.withCsvPreset()
 	.workDir(workingPath)
 	.sort(n("a"), nr("b"))
@@ -450,15 +454,15 @@ String runResult2 = Mlr.withCsvPreset()
 	.run();
 ```
 
-### `Mlr`로 체인 짜는 요령(권장 스타일)
+### `Mlr` 체인을 짤 때 제가 권하는 요령
 
-- **`Mlr.withCsvPreset()`**으로 시작하면 이미 `mlr`과 `--csv`가 깔린 상태다. 아직 작업 디렉터리는 비어 있으니 이어서 `.workDir(…)`나 `.file(…)`을 붙이면 된다. 같은 체인에 `--csv`를 한 번 더 넣고 싶다면 **`.csv()`**를 또 호출하면 된다.
-- **전역 플래그**는 `.icsv()`, `.opprint()`, **`.csv()`**, `.ocsv()`, `.ijson()`, **`.jsonFlag()`**(`--json`), `.idkvp()`, `.tsv()`, `.oxtab()`, `.ixtab()`, `.c2p()`, `.from("path")`, **`.inPlace()`**(`-I`)처럼 체인 메서드로 붙이는 쪽이 읽기 좋다. `flag(Flags…)`로도 같은 일을 할 수 있지만, 평소에는 **체인을 먼저** 쓰면 된다.
-- **동사**는 Miller와 같은 이름의 메서드가 대부분이다(예: `.uniq()`, `.histogram()`, `.join(…)`). 예외는 **`filter`** → **`.filterVerb(…)`**, **`split`** → **`.splitVerb(…)`**뿐이다. 자주 쓰는 조합은 **`.head(n)`**, **`.tail(n)`**, **`.cutFields` / `.cutOrdered` / `.cutExcept`**, **`.stats1("count", "qty")`**, **`.splitBy("shape")`**, **`.putQuiet(…)`**처럼 짧게도 부를 수 있다. 위 패턴으로 부족할 때만 **`.verb(Mlr.Verbs.foo(…))`**를 꺼내면 된다.
+- **`Mlr.withCsvPreset()`**이면 이미 `mlr`과 `--csv`가 깔린 상태입니다. 이어서 `.workDir(…)` / `.file(…)`만 붙이시면 됩니다. `--csv`를 한 번 더 넣고 싶으면 **`.csv()`**를 또 호출하세요.
+- **전역 플래그**는 `.icsv()`, `.opprint()`, **`.csv()`**, `.ocsv()`, `.ijson()`, **`.jsonFlag()`**(`--json`), `.idkvp()`, `.tsv()`, `.oxtab()`, `.ixtab()`, `.c2p()`, `.from("path")`, **`.inPlace()`**(`-I`)처럼 체인으로 붙이는 쪽을 먼저 쓰시라고 안내드립니다. `flag(Flags…)`는 그다음 선택지입니다.
+- **동사**는 Miller와 같은 이름의 메서드가 대부분입니다(예: `.uniq()`, `.histogram()`, `.join(…)`). 예외는 **`filter`** → **`.filterVerb(…)`**, **`split`** → **`.splitVerb(…)`**뿐입니다. 자주 쓰는 조합은 **`.head(n)`**, **`.tail(n)`**, **`.cutFields` / `.cutOrdered` / `.cutExcept`**, **`.stats1("count", "qty")`**, **`.splitBy("shape")`**, **`.putQuiet(…)`**처럼 짧게도 부를 수 있게 해 두었습니다. 위로 부족할 때만 **`.verb(Mlr.Verbs.foo(…))`**를 꺼내 쓰시면 됩니다.
 
-`cut`의 `-o` / `-x` / `-f`는 **`CutFlags`**와 **`.cutOrdered` / `.cutFields`**, 또는 **`.cut(option(…), option(…))`**로 맞추면 된다. `head`/`tail` 개수는 **`.head(4)`** / **`.tail(4)`** 또는 **`HeadTail.n(4)`**. `stats1`의 `-a`/`-f`/`-g`는 **`StatsFlags`**. `put -q`는 **`.putQuiet(…)`**. `split -g`는 **`.splitBy("shape")`**. 여러 동사에서 같이 쓰는 그룹핑은 **`MillerVerbOpts.groupBy("field")`**(예: `head -g`)를 참고하면 된다.
+`cut`의 `-o` / `-x` / `-f`는 **`CutFlags`**와 **`.cutOrdered` / `.cutFields`**, 또는 **`.cut(option(…), option(…))`**. `head`/`tail` 개수는 **`.head(4)`** / **`.tail(4)`** 또는 **`HeadTail.n(4)`**. `stats1`의 `-a`/`-f`/`-g`는 **`StatsFlags`**. `put -q`는 **`.putQuiet(…)`**. `split -g`는 **`.splitBy("shape")`**. 공통 그룹핑은 **`MillerVerbOpts.groupBy("field")`**(예: `head -g`)를 참고해 주세요.
 
-**`SortFlags`**는 **`n("field")`**, **`nr("field")`**, **`f("field")`**, 그리고 `head`용 맨 `-n`인 **`n()`**을 계속 쓰면 된다.
+**`SortFlags`**는 **`n("field")`**, **`nr("field")`**, **`f("field")`**, `head`용 맨 `-n`인 **`n()`**을 계속 쓰시면 됩니다.
 
 ```java
 import static net.shed.mlrbinder.SortFlags.n;
@@ -470,7 +474,7 @@ String runResult = Mlr.withCsvPreset()
 	.file(new File("example.csv"))
 	.run();
 
-// 튜토리얼에 나오는 흐름과 같은 그림
+// 튜토리얼과 같은 흐름
 String top3 = Mlr.inDir(workingPath)
 	.icsv()
 	.opprint()
@@ -480,7 +484,7 @@ String top3 = Mlr.inDir(workingPath)
 	.run();
 ```
 
-Miller의 `filter`와 `split`은 자바 예약어와 겹치니, 체인에서는 **`.filterVerb(…)`**와 **`.splitVerb(…)`**로 부르면 된다.
+`filter`와 `split`은 자바 예약어와 겹치니 체인에서는 **`.filterVerb(…)`**, **`.splitVerb(…)`**로 부르게 해 두었습니다.
 
 ```java
 import static net.shed.mlrbinder.Objective.objective;
@@ -492,13 +496,13 @@ Mlr.inDir(workingPath)
 	.run();
 ```
 
-**`file(File)`**은 작업 디렉터리가 비어 있을 때 알아서 채워 준다. 절대 경로 파일이면 부모 폴더를, 상대 경로면 `user.dir`을 기준으로 잡는다. 마음에 안 들면 언제든 `workDir(String)`이나 `workingPath(String)`으로 덮어쓰면 된다.
+**`file(File)`**은 작업 디렉터리가 비어 있을 때 제가 편의로 채워 넣게 해 두었습니다. 절대 경로면 부모 폴더, 상대 경로면 `user.dir` 기준입니다. 마음에 안 드시면 `workDir(String)`이나 `workingPath(String)`으로 언제든 덮어쓰시면 됩니다.
 
 ---
 
-## 더 알아보기
+## 마무리하며 — 한 번만 들러 주세요
 
-- **소스와 이슈, 기여:** [https://github.com/bluedskim/mlrBinder](https://github.com/bluedskim/mlrBinder)
+- **저장소·이슈·기여:** [https://github.com/bluedskim/mlrBinder](https://github.com/bluedskim/mlrBinder)
 - **Miller 공식 문서:** [https://miller.readthedocs.io/](https://miller.readthedocs.io/)
 
-Miller는 그대로 두고 JVM 쪽만 **읽기 좋은 체인 API**로 감싸고 싶다면 mlr-binder를 한번 의존성에 넣어 보시길 권한다. 버전이나 좌표는 시간이 지나면 바뀔 수 있으니, 쓰시기 직전에 GitHub README와 Maven Central을 함께 확인해 주시면 가장 안전하다.
+JVM에서 Miller를 **그대로 두고** 호출만 정리하고 싶으시다면, mlr-binder를 의존성에 한 줄 넣어 보시길 부탁드립니다. 버그나 불편한 점, “이런 동사도 체인에 붙이고 싶다” 같은 이야기는 **GitHub 이슈**로 보내 주시면 제가 직접 보면서 반영하겠습니다. 스타 한 번, 포크 한 번도 큰 힘이 됩니다. 읽어 주셔서 고맙습니다.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the mlrBinder tech post for a promotional, reader-friendly tone: removes explicit “translation/README” framing, retitles the post, rewrites the intro and section headings in warmer Korean (합쇼체·친절한 안내), softens imperative phrasing where it felt blunt, and expands the closing and API cheat-sheet sections with clearer guidance. Technical content and code blocks are unchanged in substance.

Follow-up: the post now opens with a clear disclosure that the author maintains mlrBinder, reframes the whole article in first-person author voice (왜 만들었는지, 어떻게 쓰면 좋은지), adds front matter `description`, and ends with a direct invitation for issues, stars, and forks.

Hugo was not run in this environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-966792b2-867d-4ce1-ae2e-e5c3652616ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-966792b2-867d-4ce1-ae2e-e5c3652616ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

