### PR TITLE
Use local publishDir during hugo server for faster reloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .hugo_build.lock
+.hugo/

--- a/config.development.toml
+++ b/config.development.toml
@@ -1,0 +1,3 @@
+# Used automatically by `hugo server` (development environment).
+# Avoids writing every rebuild to ../bluedskim.github.io (slow sync / live reload).
+publishDir = ".hugo/public"

--- a/config.toml
+++ b/config.toml
@@ -14,6 +14,7 @@ pagerSize = 5
 googleAnalytics = "UA-108812986-1"
 disqusShortname = "bluedskim"
 enableRobotsTXT = true
+# Production deploy target. Local `hugo server` overrides via config.development.toml.
 publishDir = "../bluedskim.github.io"
 hasCJKLanguage = true
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`hugo server` runs in Hugo's **development** environment. This change adds `config.development.toml` so the dev server writes builds to `.hugo/public` instead of `../bluedskim.github.io`.

## Why

The main `config.toml` sets `publishDir` to a sibling GitHub Pages repo. On every file change, Hugo syncs the full site there. That path often triggers slow I/O (another repo, sync tools, antivirus), which makes static updates and live reload feel sluggish.

Production `hugo` / `hugo build` still uses `publishDir = "../bluedskim.github.io"` from the root config.

## Notes

- `.hugo/` is gitignored so dev output stays out of commits.
- Optional: add `--renderToMemory` or `--M` if disk writes are still a bottleneck (Hugo docs).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d492976a-cee3-4215-b4d4-00ff407dfe33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d492976a-cee3-4215-b4d4-00ff407dfe33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

